### PR TITLE
fix(youtube): disable zo-dependent player optimization

### DIFF
--- a/473972.user.js
+++ b/473972.user.js
@@ -10263,7 +10263,7 @@
 
     FIX_yt_player && !isChatRoomURL && (async () => {
 
-      const fOption = 1 | 0 | 4 | 8; // PR#105
+      const fOption = 1 | 0 | 4 | 8; // See PR#105
 
       const _yt_player = await _yt_player_observable.obtain();
 

--- a/473972.user.js
+++ b/473972.user.js
@@ -10083,7 +10083,7 @@
 
     FIX_yt_player && !isChatRoomURL && (async () => {
 
-      const fOption = 1 | 2 | 4;
+      const fOption = 1 | 4;
 
       const _yt_player = await _yt_player_observable.obtain();
 


### PR DESCRIPTION
Disabled the `PERF_471489_ path` to avoid key-extraction warnings when YouTube's obfuscated player internals no longer expose the expected `zo` helper.